### PR TITLE
fix: wrangler.tomlにvarsを追加し、500を回避するように

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -10,3 +10,6 @@ compatibility_date = "2026-04-01"
 
 [assets]
 directory = "./dist"
+
+[vars]
+STATIC_DATA_URL="https://r2.shinkan2026.tsukuba.dev"


### PR DESCRIPTION
## 現状
- Cloudulareのビルド時に環境変数がなく、トップページなどで500エラーが返ってしまう

## 行ったこと
- wrangler.tomlに環境変数を追加し、500エラーが起きないよう修正