### PR TITLE
ひらがな等による検索などに対応した正規化を検索へ実装

### DIFF
--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -137,6 +137,8 @@ const counts: any = process.env.CATEGORY_COUNTS ?? [];
 </style>
 
 <script>
+  import { buildSearchAliases, normalizeSearchText } from "../utils/search";
+
   const search = document.querySelector(".search")! as HTMLFormElement;
   const observer = new IntersectionObserver((entries) => {
     for (const entry of entries) {
@@ -188,46 +190,75 @@ const counts: any = process.env.CATEGORY_COUNTS ?? [];
   });
   await pagefind.init();
 
-  const normalizeSearchText = (value: string) => value.normalize("NFKC").toLowerCase().replace(/\s+/g, "");
-
   const scoreOrgResult = (org: any, query: string) => {
-    const normalizedQuery = normalizeSearchText(query);
-    if (normalizedQuery.length === 0) return 0;
+    const normalizedQueries = buildSearchAliases(query).map((alias) => normalizeSearchText(alias));
+    if (normalizedQueries.length === 0) return 0;
 
     const title = normalizeSearchText(org.meta?.title ?? "");
     const keywords = normalizeSearchText(org.meta?.keywords ?? "");
     const kana = normalizeSearchText(org.meta?.kana ?? "");
 
-    let score = 0;
+    return normalizedQueries.reduce((bestScore, normalizedQuery) => {
+      let score = 0;
 
-    if (title === normalizedQuery) score += 300;
-    if (title.startsWith(normalizedQuery)) score += 180;
-    if (title.includes(normalizedQuery)) score += 120;
-    if (keywords.includes(normalizedQuery)) score += 80;
-    if (kana.includes(normalizedQuery)) score += 60;
+      if (title === normalizedQuery) score += 300;
+      if (title.startsWith(normalizedQuery)) score += 180;
+      if (title.includes(normalizedQuery)) score += 120;
+      if (keywords.includes(normalizedQuery)) score += 80;
+      if (kana === normalizedQuery) score += 240;
+      if (kana.startsWith(normalizedQuery)) score += 180;
+      if (kana.includes(normalizedQuery)) score += 120;
 
-    return score;
+      return Math.max(bestScore, score);
+    }, 0);
   };
 
   text.addEventListener("input", () => {
-    const query = text.value;
-    if (query.length > 0) {
-      pagefind.preload(query);
+    const aliases = buildSearchAliases(text.value);
+    if (aliases.length > 0) {
+      aliases.forEach((alias) => pagefind.preload(alias));
     }
   });
 
   const searchOrgs = async () => {
     const query = text.value;
-    const searchResults = await pagefind.search(query);
-    const orgs = await Promise.all(searchResults.results.map((r: any) => r.data()));
+    const aliases = buildSearchAliases(query);
+    if (aliases.length === 0) return [];
 
-    const rankedOrgs = orgs
-      .map((org, index) => ({
+    const searches = await Promise.all(
+      aliases.map(async (alias, aliasIndex) => {
+        const searchResults = await pagefind.search(alias);
+        return searchResults.results.map((result: any, resultIndex: number) => ({
+          result,
+          aliasIndex,
+          resultIndex,
+        }));
+      })
+    );
+
+    const mergedResults = new Map<string, { org: any; rank: number }>();
+
+    for (const resultGroup of searches) {
+      for (const { result, aliasIndex, resultIndex } of resultGroup) {
+        const rank = aliasIndex * 1000 + resultIndex;
+        const url = result.url as string;
+        const existing = mergedResults.get(url);
+        if (existing && existing.rank <= rank) continue;
+
+        mergedResults.set(url, {
+          org: await result.data(),
+          rank,
+        });
+      }
+    }
+
+    const rankedOrgs = [...mergedResults.values()]
+      .map(({ org, rank }) => ({
         org,
-        index,
+        rank,
         score: scoreOrgResult(org, query),
       }))
-      .sort((a, b) => b.score - a.score || a.index - b.index)
+      .sort((a, b) => b.score - a.score || a.rank - b.rank)
       .map(({ org }) => org);
 
     const ids = rankedOrgs

--- a/src/pages/orgs/[id].astro
+++ b/src/pages/orgs/[id].astro
@@ -7,6 +7,7 @@ import { getOrganizations } from "../../lib/organizations";
 import { marked } from "marked";
 import { enumerateContactInfomations } from "../../utils/organization";
 import { processEmbeds } from "../../utils/embedProcessor";
+import { normalizeSearchText } from "../../utils/search";
 import type { Organization } from "../../types";
 
 import "@splidejs/splide/css";
@@ -45,6 +46,7 @@ const images = org.attributes.images.data
 
 const tags = org.attributes.tags;
 const tagTexts = tags?.map((tag) => tag.display_string) ?? [];
+const searchableKana = normalizeSearchText(org.attributes.name_kana);
 ---
 
 <Layout
@@ -60,6 +62,7 @@ const tagTexts = tags?.map((tag) => tag.display_string) ?? [];
       <span data-pagefind-meta="kana">{org.attributes.name_kana}</span>
       <span data-pagefind-meta="keywords">{tagTexts.join(" ")}</span>
     </div>
+    <span class="pagefind-searchable-text">{searchableKana}</span>
     <a href="/" class="back" data-pagefind-ignore="all">一覧へ戻る</a>
     <div class="title-line">
       <h1 class="name" data-pagefind-weight="10">{org.attributes.name}</h1>
@@ -166,6 +169,17 @@ const tagTexts = tags?.map((tag) => tag.display_string) ?? [];
     margin-block-end: 1rem;
   }
   .pagefind-meta {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  .pagefind-searchable-text {
     position: absolute;
     width: 1px;
     height: 1px;

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,0 +1,15 @@
+const KATAKANA_START = 0x30a1;
+const KATAKANA_END = 0x30f6;
+const HIRAGANA_KATAKANA_DIFF = 0x60;
+
+export const toHiragana = (value: string) =>
+  [...value].map((char) => {
+    const codePoint = char.codePointAt(0);
+    if (!codePoint || codePoint < KATAKANA_START || codePoint > KATAKANA_END) return char;
+    return String.fromCodePoint(codePoint - HIRAGANA_KATAKANA_DIFF);
+  }).join("");
+
+export const normalizeSearchText = (value: string) => toHiragana(value.normalize("NFKC").toLowerCase()).replace(/\s+/g, "");
+
+export const buildSearchAliases = (query: string) =>
+  [...new Set([query.trim(), normalizeSearchText(query)].filter((value) => value.length > 0))];


### PR DESCRIPTION
ひらがな等による検索などに対応した正規化を検索へ実装した。
要レビュー。初回リリースには必須でなく、どこか任意のタイミングで追加でok。
Resolves #15 